### PR TITLE
made tableFormats Py3-compatible and added it in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     author='Luke Maurits',
     author_email='luke@maurits.id.au',
     url='http://code.google.com/p/prettytable',
-    py_modules=['prettytable'],
+    py_modules=['prettytable', 'tableFormats'],
     test_suite = "prettytable_test"
 )

--- a/tableFormats.py
+++ b/tableFormats.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from prettytable import PrettyTable
 import abc
 
@@ -71,13 +72,13 @@ if __name__ == "__main__":
     t = PrettyTable(['a','b','c'])
     t.add_row([1,2.0,3.14159])
     xt = latexTable(t,caption='Testing formatted table string',label='tab:test')
-    print '1. Simply print the table:\n'
-    print xt
-    print '\n2. Use get_string method:\n'
-    print xt.get_string()
-    print '\n3. Format floats to two decimal points: (KNOWN ISSUE)\n'
-    print xt.get_string(float_format='0.2')
-    print '\n4. Workaround to format floats:\n'
+    print('1. Simply print the table:\n')
+    print(xt)
+    print('\n2. Use get_string method:\n')
+    print(xt.get_string())
+    print('\n3. Format floats to two decimal points: (KNOWN ISSUE)\n')
+    print(xt.get_string(float_format='0.2'))
+    print('\n4. Workaround to format floats:\n')
     t.float_format = '0.2'
     xt2 = latexTable(t,caption='Floats are formatted to have two decimal places',label='tab:test2')
-    print xt2
+    print(xt2)


### PR DESCRIPTION
Hi,
This is my first pull-request.
I really liked the ability to print latex tables, thanks for that!
I changed two things:
- made tableFormats.py Python3 compatible (just applied futurize --stage1)
- added tableFormats in setup.py, so it would be installed when using pip. This may or may not be a good idea.

I hope this makes sense.
Thanks